### PR TITLE
added support for additional sharing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,41 @@ Below is a sample use case. Feel free to add the videojs-socialShare CSS/JS to y
       handle: '', // optional, appends `via @handle` to the end of the tweet 
       shareUrl: '', // optional, defaults to window.location.href
       shareText: '' 
+    },
+    embed: { // optional, includes an embed code button
+      embedMarkup: 'YOURMARKUPHERE' // required
     }
   });
 </script>
 ```
+
+The order in which the options are listed in the configuration object governs
+the order in which the buttons will appear.
+
+You can also specify additional sharing mechanisms.  These are specified with 
+an icon (in SVG format) and a callback function, as shown below:
+
+```html
+<script>
+  'use strict';
+  
+  var video = videojs('my-video');
+  video.socialShare({
+    email: { 
+      iconsvg: '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" viewBox="0 0 36 36" height="36" width="36" role="presentation" class="vjs-social-share-svg"><path fill="#759e26" clip-rule="evenodd" fill-rule="evenodd" d="M5.4 0h25.2c3 0 5.4 2.4 5.4 5.4v25.2c0 3-2.4 5.4-5.4 5.4h-25.2c-3 0-5.4-2.4-5.4-5.4v-25.2c0-3 2.4-5.4 5.4-5.4z" /><path style="fill:#ffffff" d="m 28.278854,15.149222 0,9.114453 c 0,0.481822 -0.160607,0.923492 -0.521972,1.284858 -0.361366,0.361366 -0.803036,0.521973 -1.325009,0.521973 l -16.8637459,0 c -0.5219722,0 -0.9636407,-0.160607 -1.3250063,-0.521973 C 7.8817529,25.187167 7.7211456,24.745497 7.7211456,24.263675 l 0,-9.114453 c 0.3212146,0.361369 0.7227335,0.68258 1.164402,1.003795 2.7704734,1.887135 4.6576064,3.171991 5.7015514,3.934875 0.441671,0.321215 0.803037,0.602276 1.043946,0.762883 0.281064,0.160607 0.642429,0.361365 1.084099,0.562124 0.48182,0.160607 0.883339,0.281063 1.284856,0.281063 l 0,0 c 0.401519,0 0.803036,-0.120456 1.284858,-0.281063 0.441668,-0.200759 0.803036,-0.401517 1.084097,-0.562124 0.240911,-0.160607 0.602277,-0.441668 1.043945,-0.762883 1.325009,-0.923492 3.212142,-2.248501 5.701553,-3.934875 0.44167,-0.321215 0.843187,-0.642426 1.164401,-1.003795 z m 0,-3.372749 c 0,0.602278 -0.200758,1.164402 -0.562124,1.726528 -0.361365,0.562124 -0.843186,1.003795 -1.405313,1.405312 -2.850774,2.007588 -4.657605,3.252293 -5.380336,3.734114 -0.04015,0.04015 -0.240912,0.160608 -0.481822,0.361366 -0.240912,0.160607 -0.44167,0.321215 -0.602277,0.441671 -0.160607,0.0803 -0.361366,0.200758 -0.602275,0.361365 -0.240913,0.120456 -0.441671,0.24091 -0.642429,0.321215 -0.240913,0.04015 -0.40152,0.0803 -0.602278,0.0803 l 0,0 c -0.200759,0 -0.361366,-0.04015 -0.602275,-0.0803 -0.200761,-0.0803 -0.401519,-0.200759 -0.64243,-0.321215 -0.240911,-0.160607 -0.44167,-0.281063 -0.602277,-0.361365 C 15.992411,19.325008 15.791653,19.1644 15.550743,19.003793 15.309831,18.803035 15.109072,18.682579 15.068921,18.642427 14.34619,18.160606 13.342395,17.437874 12.057538,16.554536 10.732529,15.631044 9.9696464,15.109071 9.6885833,14.908313 9.2067622,14.587098 8.7650937,14.145427 8.3635747,13.583303 7.921907,13.021179 7.7211456,12.499207 7.7211456,12.017385 c 0,-0.602278 0.1606073,-1.084097 0.4818218,-1.485616 C 8.524182,10.130252 8.965852,9.9294937 9.5681271,9.9294937 l 16.8637459,0 c 0.521973,0 0.923492,0.2007583 1.284857,0.5621233 0.361366,0.361366 0.562124,0.762883 0.562124,1.284856 z" /></svg>',
+      callback: function (e)
+      {
+        // implement the actual sharing here...
+        alert ("you clicked the share via email button!");
+      }
+    }
+  });
+</script>
+```
+
+You can use any legal Javascript property name you want for these additional
+sharing options; you just can't use any of the pre-defined names (facebook,
+twitter, embed).
 
 ### Notes
 For Facebook to work to the best of its ability, you need to have implemented the Facebook SDK or at least the og metadata, include the `fb:app_id`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Below is a sample use case. Feel free to add the videojs-socialShare CSS/JS to y
     facebook: { // optional, includes a Facebook share button (See the [Facebook documentation](https://developers.facebook.com/docs/sharing/reference/share-dialog) for more information)
       shareUrl: '', // optional, defaults to window.location.href
       shareImage: '', // optional, defaults to the Facebook-scraped image
-      shareText: ''
+      shareText: '',  // optional
+      app_id: '', // optional, facebook app_id to use (if not specified, the plugin will try to 
+                  // use an existing FB Javascript object, or it will try to scrape the app_id from the 
+                  // <meta property="fb:app_id"> element in the document
     },
     twitter: { // optional, includes a Twitter share button (See the [Twitter documentation](https://dev.twitter.com/web/tweet-button/web-intent) for more information)
       handle: '', // optional, appends `via @handle` to the end of the tweet 

--- a/videojs.socialShare.css
+++ b/videojs.socialShare.css
@@ -17,7 +17,7 @@
 }
 .vjs-user-inactive.vjs-paused .vjs-social-share {
     visibility: visible;
-    opacity: 0;
+    opacity: 1;
 }
 .vjs-ad-playing .vjs-social-share {
     display: none;
@@ -60,7 +60,7 @@
 }
 .vjs-user-inactive.vjs-paused .embed-window {
     visibility: visible;
-    opacity: 0;
+    opacity: 1;
 }
 .vjs-ad-playing .embed-window {
     display: none;

--- a/videojs.socialShare.css
+++ b/videojs.socialShare.css
@@ -1,19 +1,28 @@
 .vjs-social-share {
   height: 40px;
-  opacity: 0;
   position: absolute;
   right: 30px;
   text-align: center;
   top: 14px;
-  -webkit-transition: opacity .3s ease-in-out;
-  transition: opacity .3s ease-in-out;
+  transition: visibility 0.3s ease 0s, opacity 0.3s ease 0s;
   width: auto;
   z-index: 999;
-}
-.vjs-social-share.is-visible,
-.vjs-social-share:hover {
+  visibility: visible;
   opacity: 1;
 }
+
+.vjs-user-inactive .vjs-social-share {
+    visibility: hidden;
+    opacity: 0;
+}
+.vjs-user-inactive.vjs-paused .vjs-social-share {
+    visibility: visible;
+    opacity: 0;
+}
+.vjs-ad-playing .vjs-social-share {
+    display: none;
+}
+
 .vjs-social-share-link {
   border: none;
   cursor: pointer;
@@ -31,26 +40,32 @@
   width: 30px;
 }
 
-
-.vjs-user-inactive .vjs-user-inactive .embed-window {
-    -webkit-transition: visibility 1.5s, opacity 1.5s !important;
-    -moz-transition: visibility 1.5s, opacity 1.5s !important;
-    -ms-transition: visibility 1.5s, opacity 1.5s !important;
-    -o-transition: visibility 1.5s, opacity 1.5s !important;
-    transition: visibility 1.5s, opacity 1.5s !important;
-}
-
 .embed-window {
     position: absolute;
     top: 64px;
     left: 10%;
     width: 80%;
     color: black;
-    display: none;
     background: rgba(43, 51, 63, 1);
     padding: 10px;
     border-radius: 8px;
+    transition: visibility 0.3s ease 0s, opacity 0.3s ease 0s;
+    visibility: visible;
+    opacity: 1;
 }
+
+.vjs-user-inactive .embed-window {
+    visibility: hidden;
+    opacity: 0;
+}
+.vjs-user-inactive.vjs-paused .embed-window {
+    visibility: visible;
+    opacity: 0;
+}
+.vjs-ad-playing .embed-window {
+    display: none;
+}
+
 
 .embed-window .embed-window-title {
     font-size: 20px;

--- a/videojs.socialShare.css
+++ b/videojs.socialShare.css
@@ -80,3 +80,21 @@
     margin-bottom: 5px;
     cursor: pointer;
 }
+
+.embed-window button#btn-copy {
+    background-color: #3B4554;
+    border: 1px solid #808080;
+    color: white;
+    float: right;
+    margin: 8px 0;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;    
+}
+
+.embed-window button#btn-copy:active {
+    background-color: #808080;
+    color: #3B4554;
+}

--- a/videojs.socialShare.css
+++ b/videojs.socialShare.css
@@ -30,3 +30,53 @@
   height: 30px;
   width: 30px;
 }
+
+
+.vjs-user-inactive .vjs-user-inactive .embed-window {
+    -webkit-transition: visibility 1.5s, opacity 1.5s !important;
+    -moz-transition: visibility 1.5s, opacity 1.5s !important;
+    -ms-transition: visibility 1.5s, opacity 1.5s !important;
+    -o-transition: visibility 1.5s, opacity 1.5s !important;
+    transition: visibility 1.5s, opacity 1.5s !important;
+}
+
+.embed-window {
+    position: absolute;
+    top: 64px;
+    left: 10%;
+    width: 80%;
+    color: black;
+    display: none;
+    background: rgba(43, 51, 63, 1);
+    padding: 10px;
+    border-radius: 8px;
+}
+
+.embed-window .embed-window-title {
+    font-size: 20px;
+    color: #FFF;
+    margin-top: 6px;
+    margin-left: 1px;
+    display: inline-block;
+}
+
+.embed-window input {
+    width: 100%;
+    background: rgba(43, 51, 63, 0);
+    border: 1px solid gray;
+    margin-bottom: 0;
+    color: white;
+    font-size: 14px;
+    padding: 6px 10px;
+}
+
+.embed-window .embed-window-close {
+    display: inline-block;
+    float: right;
+    color: white;
+    font-size: 1.5em;
+    background: rgba(43, 51, 63, 0);
+    padding: 3px;
+    margin-bottom: 5px;
+    cursor: pointer;
+}

--- a/videojs.socialShare.js
+++ b/videojs.socialShare.js
@@ -80,7 +80,7 @@
       {
         _embed_window = document.createElement('div');
         _embed_window.className = 'embed-window';
-        _embed_window.innerHTML = '<input type="text" name="embed-code" class="mm-embed-code" readonly="readonly" onClick="this.setSelectionRange(0, this.value.length);">';
+        _embed_window.innerHTML = '<input type="text" name="embed-code" class="embed-code" readonly="readonly"><br /><button id="btn-copy">Copy</button>';
 
         var embed_close = document.createElement('div');
         embed_close.className = "embed-window-close";
@@ -95,6 +95,20 @@
         _embed_window.insertBefore(embed_title, _embed_window.firstChild);
 
         player.el().appendChild(_embed_window);
+
+        var el_btn = _embed_window.getElementsByTagName('button')[0];
+        el_btn.addEventListener('click', function(event) {
+          var el_input = _embed_window.getElementsByTagName('input')[0];
+          el_input.setSelectionRange (0, opts.embed.embedMarkup.length);
+
+          try {
+            document.execCommand('copy');
+          }
+          catch (err) {
+            console.log('unable to copy embed code to clipboard.');
+          }
+          _embed_window.style.display = 'none';
+        });
       }
 
       if (_embed_window.style.display === 'block')
@@ -103,6 +117,10 @@
       }
       else 
       {
+        var el_input = _embed_window.getElementsByTagName('input')[0];
+        el_input.value = opts.embed.embedMarkup;
+        el_input.setSelectionRange (0, opts.embed.embedMarkup.length);
+
         _embed_window.getElementsByTagName('input')[0].value = opts.embed.embedMarkup;
         _embed_window.style.display = 'block';
       }

--- a/videojs.socialShare.js
+++ b/videojs.socialShare.js
@@ -41,6 +41,12 @@
     function launchFacebook(e) {
       e.preventDefault();
       var url = opts.facebook.shareUrl ? opts.facebook.shareUrl : window.location.href;
+      var fb_app_id = opts.facebook.app_id ? opts.facebook.app_id : '';
+      if (fb_app_id == '') {
+            if (!!document.querySelector('meta[property="fb:app_id"]')) {
+                fb_app_id = document.querySelector('meta[property="fb:app_id"]').content;
+            }
+      }
 
       if (typeof FB !== 'undefined') {
         // assumes you have the proper og metadata filled out for your site
@@ -53,11 +59,11 @@
           description: opts.facebook.shareText ? opts.facebook.shareText : ''
         }, function (response) {
         });
-      } else if (!!document.querySelector('meta[property="fb:app_id"]')) {
+      } else if (fb_app_id !== '') {
         // since the FB object doesn't exist, try to scrape the page for og information and use a new window URL method
         window.open(
           'https://www.facebook.com/dialog/share' +
-            '?app_id=' + document.querySelector('meta[property="fb:app_id"]').content +
+            '?app_id=' + fb_app_id +
             '&display=popup' +
             '&href=' + encodeURIComponent(url) +
             '&redirect_uri=' + encodeURIComponent(url),

--- a/videojs.socialShare.js
+++ b/videojs.socialShare.js
@@ -105,14 +105,41 @@
         var el_btn = _embed_window.getElementsByTagName('button')[0];
         el_btn.addEventListener('click', function(event) {
           var el_input = _embed_window.getElementsByTagName('input')[0];
+          el_input.focus ();
           el_input.setSelectionRange (0, opts.embed.embedMarkup.length);
 
+          /*
+          var selectedText = ""
+          selectedText = el_input.value.substring(el_input.selectionStart, el_input.selectionEnd);
+          console.log ("selected from " + el_input.selectionStart + " to " + el_input.selectionEnd + ": " + selectedText);
+          */
+
+          var result = false;
           try {
-            document.execCommand('copy');
+            result = document.queryCommandSupported('copy');
+            if (result)
+            {
+                console.log ("copy is supported");
+            }
+            else
+            {
+                console.log ("copy is not supported");
+            }
+            result = document.execCommand('copy');
           }
           catch (err) {
+            result = false;
+          }
+
+          if (result)
+          {
+            console.log('copied embed code to clipboard.');
+          }
+          else
+          {
             console.log('unable to copy embed code to clipboard.');
           }
+
           _embed_window.style.display = 'none';
         });
       }

--- a/videojs.socialShare.js
+++ b/videojs.socialShare.js
@@ -14,6 +14,7 @@
     var _ss;
     var fbIcon = '<svg class="vjs-social-share-svg" xmlns="http://www.w3.org/2000/svg" role="presentation" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMinYMin meet"><path fill-rule="evenodd" clip-rule="evenodd" fill="#3E5C9B" d="M5.4 0h25.2c3 0 5.4 2.4 5.4 5.4v25.2c0 3-2.4 5.4-5.4 5.4h-25.2c-3 0-5.4-2.4-5.4-5.4v-25.2c0-3 2.4-5.4 5.4-5.4z"></path><path fill="#fff" d="M19.4 28v-9.2h4l.6-3.3h-4.6v-2.4c0-1.1.3-1.8 2-1.8h2.6v-3.1c-.4 0-1.1-.2-2.6-.2-3.1 0-5.7 1.8-5.7 5v2.5h-3.7v3.3h3.7v9.2h3.7z"></path></svg>';
     var twIcon = '<svg class="vjs-social-share-svg" xmlns="http://www.w3.org/2000/svg" role="presentation" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMinYMin meet"><path fill-rule="evenodd" clip-rule="evenodd" fill="#28A9E1" d="M5.4 0h25.2c3 0 5.4 2.4 5.4 5.4v25.2c0 3-2.4 5.4-5.4 5.4h-25.2c-3 0-5.4-2.4-5.4-5.4v-25.2c0-3 2.4-5.4 5.4-5.4z"></path><path fill="#fff" d="M28.2 12.3c-.7.3-1.4.5-2.2.6.8-.5 1.4-1.2 1.7-2.1-.7.4-1.5.7-2.4.9-.7-.7-1.7-1.2-2.8-1.2-2.1 0-3.8 1.7-3.8 3.8 0 .3 0 .6.1.9-3.1-.2-5.9-1.7-7.8-3.9-.3.6-.5 1.2-.5 1.9 0 1.3.7 2.5 1.7 3.1-.6 0-1.2-.2-1.7-.5 0 1.8 1.3 3.3 3 3.7-.3.1-.6.1-1 .1-.2 0-.5 0-.7-.1.5 1.5 1.9 2.6 3.5 2.6-1.3 1-2.9 1.6-4.7 1.6-.3 0-.6 0-.9-.1 1.7 1.1 3.6 1.7 5.8 1.7 6.9 0 10.7-5.7 10.7-10.7v-.5c.8-.4 1.5-1 2-1.8z"></path></svg>';
+    var embedIcon = '<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet" viewBox="0 0 36 36" height="36" width="36" role="presentation" class="vjs-social-share-svg"><path fill-rule="evenodd" clip-rule="evenodd" fill="#666" d="M5.4 0h25.2c3 0 5.4 2.4 5.4 5.4v25.2c0 3-2.4 5.4-5.4 5.4h-25.2c-3 0-5.4-2.4-5.4-5.4v-25.2c0-3 2.4-5.4 5.4-5.4z"></path><path fill="#fff" d="m 15.110455,24.59026 -1.59668,1.611328 -9.8437499,-8.217774 9.8437499,-8.2177732 1.59668,1.6259762 -7.9833986,6.5625 7.9833986,6.635743 z"></path><path fill="#fff" d="m 21.24815,11.392017 1.582031,-1.6259762 9.84375,8.2177732 -9.84375,8.217774 -1.582031,-1.611328 7.983399,-6.577149 -7.983399,-6.621094 z" ></path></svg>';
 
     /**
      * Launches the Twitter Web Intent form in a new window
@@ -71,6 +72,42 @@
       }
     }
 
+    var _embed_window = null;
+    function launchEmbed(e) {
+      e.preventDefault();
+
+      if (_embed_window === null)
+      {
+        _embed_window = document.createElement('div');
+        _embed_window.className = 'embed-window';
+        _embed_window.innerHTML = '<input type="text" name="embed-code" class="mm-embed-code" readonly="readonly" onClick="this.setSelectionRange(0, this.value.length);">';
+
+        var embed_close = document.createElement('div');
+        embed_close.className = "embed-window-close";
+        embed_close.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24"><path fill="#fff" id="path9812" d="m 3.9425039,20.057495 c -4.45165455,-4.451654 -4.45165455,-11.6633357 0,-16.1149908 4.4516552,-4.45165472 11.6633371,-4.45165472 16.1149911,0 4.451656,4.4516551 4.451656,11.6633368 0,16.1149908 -4.451654,4.451656 -11.6633359,4.451656 -16.1149911,0 z M 18.054251,5.9457492 c -3.338741,-3.3387414 -8.7697602,-3.3387414 -12.1085023,0 -3.338741,3.338741 -3.338741,8.7697618 0,12.1085018 3.3387421,3.338741 8.7697613,3.338741 12.1085023,0 3.338741,-3.33874 3.338741,-8.7697608 0,-12.1085018 z M 8.9728744,17.030371 6.9696295,15.027126 9.996756,12 6.9696295,8.9728742 8.9728744,6.9696296 12.000001,9.9967548 15.027127,6.9696296 17.030371,8.9728742 14.003246,12 l 3.027125,3.027126 -2.003244,2.003245 -3.027126,-3.027126 z" /></svg>';
+
+        embed_close.onclick = launchEmbed;
+        _embed_window.insertBefore(embed_close, _embed_window.firstChild);
+
+        var embed_title = document.createElement('span');
+        embed_title.className = 'embed-window-title';
+        embed_title.innerHTML = 'Embed Video';
+        _embed_window.insertBefore(embed_title, _embed_window.firstChild);
+
+        player.el().appendChild(_embed_window);
+      }
+
+      if (_embed_window.style.display === 'block')
+      {
+        _embed_window.style.display = 'none';
+      }
+      else 
+      {
+        _embed_window.getElementsByTagName('input')[0].value = opts.embed.embedMarkup;
+        _embed_window.style.display = 'block';
+      }
+    }
+
     /**
      * Generate the DOM elements for the social share tool
      * @type {function}
@@ -80,21 +117,55 @@
       var _aside = document.createElement('aside');
       var _button;
 
-      // fill in specific Twitter settings, if available
-      if (opts.twitter) {
-        _button = document.createElement('a');
-        _button.className = 'vjs-social-share-link';
-        _button.innerHTML = twIcon;
-        _button.addEventListener('click', launchTweet, false);
-        _aside.appendChild(_button);
+      var channel = '';
+      for (channel in opts)
+      {
+        switch (channel)
+        {
+          case 'twitter':
+            _button = document.createElement('a');
+            _button.className = 'vjs-social-share-link';
+            _button.innerHTML = twIcon;
+            _button.addEventListener('click', launchTweet, false);
+            _aside.appendChild(_button);
+            break;
+
+          case 'facebook':
+            _button = document.createElement('a');
+            _button.className = 'vjs-social-share-link';
+            _button.innerHTML = fbIcon;
+            _button.addEventListener('click', launchFacebook, false);
+            _aside.appendChild(_button);
+            break;
+
+          case 'embed':
+            _button = document.createElement('a');
+            _button.className = 'vjs-social-share-link';
+            _button.innerHTML = embedIcon;
+            _button.addEventListener('click', launchEmbed, false);
+            _aside.appendChild(_button);
+            break;
+
+          default:
+            if ((typeof opts[channel].iconsvg !== 'undefined')
+                && (typeof opts[channel].callback === 'function'))
+            {
+                _button = document.createElement('a');
+                _button.className = 'vjs-social-share-link';
+                _button.innerHTML = opts[channel].iconsvg;
+                _button.addEventListener('click', function (e) { opts[channel].callback (e); }, false);
+                _aside.appendChild(_button);
+            }
+            break;
+        }
       }
-      // fill in specific Facebook settings, if available
-      if (opts.facebook) {
-        _button = document.createElement('a');
-        _button.className = 'vjs-social-share-link';
-        _button.innerHTML = fbIcon;
-        _button.addEventListener('click', launchFacebook, false);
-        _aside.appendChild(_button);
+
+      // remove previously created elements (e.g. the user calls the plugin multiple
+      // times as videos are changed out)
+      var el = player.el().querySelector(".vjs-social-share");
+      if (el)
+      {
+        el.remove ();
       }
 
       _aside.className = 'vjs-social-share';
@@ -114,9 +185,7 @@
     });
 
     player.ready(function() {
-      if (opts.facebook || opts.twitter) {
-        constructSocialShareContent();
-      }
+      constructSocialShareContent();
     });
 
 

--- a/videojs.socialShare.js
+++ b/videojs.socialShare.js
@@ -193,15 +193,6 @@
       player.el().appendChild(_frag);
     }
 
-    // attach VideoJS event handlers
-    player.on('mouseover', function() {
-      // on hover, fade in the social share tools
-      _ss.classList.add('is-visible');
-    }).on('mouseout', function() {
-      // when not hovering, fade share tools back out
-      _ss.classList.remove('is-visible');
-    });
-
     player.ready(function() {
       constructSocialShareContent();
     });


### PR DESCRIPTION
I extended your plugin to add support for an "embed" option.  The caller supplies the embedMarkup; when the user clicks the embed button, a popup is displayed with the markup, allowing the user to copy and paste the markup.

I added support for adding arbitrary buttons to the plugin by specifying an SVG icon along with a callback function.  So if the user of the plugin wanted a Google+ option, he could add the button and then in his callback function implement the logic for a google+ share.

I also modified the way the configuration is parsed so that you can control the order of the buttons by reordering the properties in the configuration object.
