### PR TITLE
Removed chaining of mouseover and mouseout functions

### DIFF
--- a/videojs.socialShare.js
+++ b/videojs.socialShare.js
@@ -110,7 +110,8 @@
     player.on('mouseover', function() {
       // on hover, fade in the social share tools
       _ss.classList.add('is-visible');
-    }).on('mouseout', function() {
+    });
+    player.on('mouseout', function() {
       // when not hovering, fade share tools back out
       _ss.classList.remove('is-visible');
     });


### PR DESCRIPTION
This is to address https://github.com/jmccraw/videojs-socialShare/issues/5
The chaining calls fail when using this plugin with vjs6